### PR TITLE
Add local energy monitor plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 ThisBuild / organization := "com.example"
 ThisBuild / scalaVersion := "2.13.6"
 
+enablePlugins(EnergyMonitorPlugin)
+
 lazy val root = (project in file(".")).settings(
   name := "droste-playground",
   libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.47deg" % "sbt-energymonitor" % "0.1-SNAPSHOT")


### PR DESCRIPTION
This PR exists to have somewhere to consume and post results from 47degrees/sbt-energymonitor#8. CI failures are expected since the plugin isn't actually published in real life and measuring consumption doesn't work in CI anyway, so I'll be testing from local and comments will be sent here.